### PR TITLE
Install git in the container

### DIFF
--- a/Dockerfile.create_conflict
+++ b/Dockerfile.create_conflict
@@ -1,5 +1,6 @@
 FROM public.ecr.aws/lambda/python:3.8
 
+RUN yum install -y git
 COPY requirements.txt ${LAMBDA_TASK_ROOT}
 RUN pip3 install -r requirements.txt
 COPY create_conflict.py ${LAMBDA_TASK_ROOT}


### PR DESCRIPTION

This took me **forever** to figure out!  The problem was that `git` is not installed in the based `public.ecr.aws/lambda/python` container.  When your code tries to import `git` it fails.  But because this is being run inside a docker container that is mimicking a Lambda function, the error messages are not helpful.

In the end, I found the error by trail and error.  I kept replacing your code with working code from `create_repo.py` until I got it working.  Then I started putting your code back piece by piece.  When I added `import git` back into the file, it broke as before.

UGH!